### PR TITLE
Startup Before HA And Allow USB CM19A Access

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "mochad"
 description: "Enables X-10 ActiveHome and PowerHouse devices for use in Home Assistant"
-version: 0.0.1
+version: 0.0.2
 slug: "mochad"
 uart: true
 usb: true

--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,10 @@ description: "Enables X-10 ActiveHome and PowerHouse devices for use in Home Ass
 version: 0.0.1
 slug: "mochad"
 uart: true
+usb: true
 url: "https://github.com/floridaman7588.me/mochad-ha-addon"
 init: false
+startup: services
 ports:
   1099/tcp: 1099
 ports_description:


### PR DESCRIPTION
Just a quick config file update to fix USB access error for CM19A devices