### PR TITLE
Fix installation when image missing

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.18
-  amd64: ghcr.io/home-assistant/amd64-base:3.18
-  armhf: ghcr.io/home-assistant/armhf-base:3.18
-  armv7: ghcr.io/home-assistant/armv7-base:3.18
-  i386: ghcr.io/home-assistant/i386-base:3.18
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
+  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  armhf: ghcr.io/home-assistant/armhf-base:3.19
+  armv7: ghcr.io/home-assistant/armv7-base:3.19
+  i386: ghcr.io/home-assistant/i386-base:3.19

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 slug: "mochad"
 uart: true
 usb: true
-url: "https://github.com/floridaman7588.me/mochad-ha-addon"
+url: "https://github.com/floridaman7588/mochad-ha-addon"
 init: false
 startup: services
 ports:

--- a/config.yaml
+++ b/config.yaml
@@ -25,4 +25,3 @@ schema:
     adapter: match(CM15A|CM15Pro|CM19A)?
     baudrate: int?
     rtscts: bool?
-image: ghcr.io/floridaman7588/mochad-{arch}


### PR DESCRIPTION
It looks like the github images are missing for armv7 and amd64.  This change makes it so the image is built when a user tries to install it.