### PR TITLE
Move to working mochad server

### DIFF
--- a/mochad/Dockerfile
+++ b/mochad/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update --no-cache \
     git cmake make autoconf automake \
     libusb-dev gcc g++ && \
     rm -rf /var/cache/apk /lib/apk/db && \
-    git clone https://github.com/sigmdel/mochad.git
+    git clone https://github.com/rayun56/mochad.git
 WORKDIR /tmp/mochad
 RUN mkdir build-scripts && aclocal && \
     automake --add-missing --copy && autoconf && \


### PR DESCRIPTION
As explained in my [readme](https://github.com/rayun56/mochad), the new version of the mochad server from sigmdel does not work with the mochad integration in home assistant, due to some incompatible line endings, which are not present in the *original* mochad server from way back when. I changed the dockerfile in this addon to use my fork of the mochad server, allowing it to work with the current mochad home assistant integration.